### PR TITLE
feat: Add difficulty setting to the game

### DIFF
--- a/Aichaosbrain.py
+++ b/Aichaosbrain.py
@@ -7,13 +7,15 @@ class AIChaosBrain:
     This class is designed to create surprising and dynamic gameplay moments
     based on the player's recent behavior.
     """
-    def __init__(self):
+    def __init__(self, modes_manager):
         """
         Initializes the AI brain.
+        - modes_manager: An instance of ModesManager to access difficulty settings.
         - player_moves: A list to store the player's recent actions.
         - fears: A list of potential "twist" events the AI can trigger.
         - memory_file: The file where the AI's "memory" of player moves is stored.
         """
+        self.modes_manager = modes_manager
         self.player_moves = []  # Learns your quirks
         self.fears = ['sandstorm', 'floating_islands', 'dance_or_die']  # Your nightmares
         self.memory_file = 'chaos_memory.json'  # Persists across runs
@@ -31,12 +33,20 @@ class AIChaosBrain:
 
     def throw_twist(self):
         """
-        Triggers a chaotic event based on the player's recent moves.
+        Triggers a chaotic event based on the player's recent moves and difficulty.
         If the player is defensive ('dodge'), the AI introduces a major environmental shift.
         Otherwise, it provides a more standard challenge.
         """
-        # If the player has dodged in their last 3 moves, trigger a "fear".
-        if 'dodge' in self.player_moves[-3:]:  # If you're dodging a lot...
+        difficulty = self.modes_manager.difficulty
+        twist_sensitivity = 3  # Default for medium
+
+        if difficulty == 'easy':
+            twist_sensitivity = 2
+        elif difficulty == 'hard':
+            twist_sensitivity = 4
+
+        # If the player has dodged in their last `twist_sensitivity` moves, trigger a "fear".
+        if len(self.player_moves) >= twist_sensitivity and 'dodge' in self.player_moves[-twist_sensitivity:]:
             twist = random.choice(self.fears)
             if twist == 'dance_or_die':
                 return "AI whispers: Dance for a shield, or get wrecked! Groove time."

--- a/Beast_bestiary.py
+++ b/Beast_bestiary.py
@@ -6,13 +6,15 @@ class BeastBestiary:
     Beasts are a core part of the game's reward and progression system,
     providing players with powerful mounts and abilities.
     """
-    def __init__(self, coins=0):
+    def __init__(self, modes_manager, coins=0):
         """
         Initializes the Bestiary.
+        - modes_manager: An instance of ModesManager to access difficulty settings.
         - coins: The player's current currency balance.
         - beasts: A dictionary of available beasts, their costs, and effects.
         - owned_beasts: A list of beasts the player currently owns.
         """
+        self.modes_manager = modes_manager
         self.coins = coins
         self.beasts = {
             'leo_lion': {'cost': 1, 'effect': 'Roar shakes chest – haptic thunder!'},
@@ -27,13 +29,28 @@ class BeastBestiary:
         """
         Allows a player to purchase a beast from the bestiary.
         Checks if the player has enough coins and if the beast exists.
+        Cost is adjusted based on difficulty.
         """
-        if beast_name in self.beasts and self.coins >= self.beasts[beast_name]['cost']:
-            self.coins -= self.beasts[beast_name]['cost']
+        if beast_name not in self.beasts:
+            return "Beast not found in the bestiary."
+
+        base_cost = self.beasts[beast_name]['cost']
+        difficulty = self.modes_manager.difficulty
+        cost_multiplier = 1.0
+
+        if difficulty == 'easy':
+            cost_multiplier = 0.8
+        elif difficulty == 'hard':
+            cost_multiplier = 1.5
+
+        adjusted_cost = int(base_cost * cost_multiplier)
+
+        if self.coins >= adjusted_cost:
+            self.coins -= adjusted_cost
             self.owned_beasts.append(beast_name)
-            return f"Beast acquired: {self.beasts[beast_name]['effect']} Sons' stars flare!"
+            return f"Beast acquired for {adjusted_cost} coins: {self.beasts[beast_name]['effect']} Sons' stars flare!"
         else:
-            return "Not enough coins, queen. Raid a village!"
+            return f"Not enough coins, queen. Need {adjusted_cost}, have {self.coins}. Raid a village!"
 
     def ride_beast(self, beast_name):
         """

--- a/Modes_manager.py
+++ b/Modes_manager.py
@@ -12,10 +12,22 @@ class ModesManager:
         - current_mode: The active game mode.
         - xp: The player's experience points, which are persistent.
         - shelters: A list representing player-built structures in survival mode.
+        - difficulty: The game's difficulty level.
         """
         self.current_mode = 'hunter'
         self.xp = 0
         self.shelters = []  # Persist builds
+        self.difficulty = 'medium'  # Default difficulty
+
+    def set_difficulty(self, level):
+        """
+        Sets the game's difficulty level.
+        - level: The desired difficulty ('easy', 'medium', 'hard').
+        """
+        if level in ['easy', 'medium', 'hard']:
+            self.difficulty = level
+            return f"Difficulty set to {level}."
+        return "Invalid difficulty level."
 
     def switch_mode(self, mode):
         """

--- a/chaos_memory.json
+++ b/chaos_memory.json
@@ -1,1 +1,1 @@
-{"moves": ["fight", "switch_mode hunter", "fight", "fight", "switch_mode therapy", "create", "reflect", "fight", "switch_mode hunter", "fight"]}
+{"moves": ["attack", "attack", "attack", "dodge"]}

--- a/game.py
+++ b/game.py
@@ -1,0 +1,91 @@
+from Modes_manager import ModesManager
+from Aichaosbrain import AIChaosBrain
+from Beast_bestiary import BeastBestiary
+from characters import Kate
+
+def run_game_scenario():
+    """
+    Runs a scenario to demonstrate the difficulty settings affecting the game.
+    """
+    print("--- Initializing Game ---")
+    modes_manager = ModesManager()
+    ai_brain = AIChaosBrain(modes_manager)
+    # Start with more coins to test purchases
+    bestiary = BeastBestiary(modes_manager, coins=20)
+    player = Kate()
+
+    print(f"Welcome, {player.name}! Your trait: {player.trait}")
+    print(f"Initial mode: {modes_manager.current_mode}")
+    print(f"Initial difficulty: {modes_manager.difficulty}")
+    print(f"Initial coins: {bestiary.coins}")
+    print("-" * 20)
+
+    # --- SCENARIO 1: MEDIUM DIFFICULTY (DEFAULT) ---
+    print("\n--- Scenario: Medium Difficulty ---")
+    print(f"Current difficulty: {modes_manager.difficulty}")
+
+    # Demonstrate AI twist
+    print("\nSimulating player dodging...")
+    ai_brain.learn_move('attack')
+    ai_brain.learn_move('attack')
+    ai_brain.learn_move('dodge')
+    # On medium, this is not enough to trigger a twist (needs 3 dodges in a row)
+    print("AI response (1 dodge):", ai_brain.throw_twist())
+    ai_brain.learn_move('dodge')
+    ai_brain.learn_move('dodge')
+    print("AI response (3 dodges):", ai_brain.throw_twist())
+
+    # Demonstrate beast cost
+    print("\nAttempting to buy a knight_mount (base cost 10)...")
+    print(bestiary.buy_beast('knight_mount'))
+    print(f"Coins remaining: {bestiary.coins}")
+    print("-" * 20)
+
+
+    # --- SCENARIO 2: EASY DIFFICULTY ---
+    print("\n--- Scenario: Easy Difficulty ---")
+    modes_manager.set_difficulty('easy')
+    print(f"Difficulty changed to: {modes_manager.difficulty}")
+    ai_brain.player_moves = [] # Reset moves for a clean test
+    bestiary.coins = 20 # Reset coins
+
+    # Demonstrate AI twist (less sensitive)
+    print("\nSimulating player dodging (less sensitive)...")
+    ai_brain.learn_move('dodge')
+    # On easy, 1 dodge is not enough to trigger a twist (needs 2)
+    print("AI response (1 dodge):", ai_brain.throw_twist())
+    ai_brain.learn_move('dodge')
+    print("AI response (2 dodges):", ai_brain.throw_twist())
+
+    # Demonstrate beast cost (cheaper)
+    print("\nAttempting to buy a knight_mount (base cost 10)...")
+    # Cost should be 10 * 0.8 = 8
+    print(bestiary.buy_beast('knight_mount'))
+    print(f"Coins remaining: {bestiary.coins}")
+    print("-" * 20)
+
+    # --- SCENARIO 3: HARD DIFFICULTY ---
+    print("\n--- Scenario: Hard Difficulty ---")
+    modes_manager.set_difficulty('hard')
+    print(f"Difficulty changed to: {modes_manager.difficulty}")
+    ai_brain.player_moves = [] # Reset moves
+    bestiary.coins = 20 # Reset coins
+
+    # Demonstrate AI twist (more sensitive)
+    print("\nSimulating player dodging (more sensitive)...")
+    ai_brain.learn_move('attack')
+    ai_brain.learn_move('attack')
+    ai_brain.learn_move('attack')
+    ai_brain.learn_move('dodge')
+    # On hard, even one dodge in the last 4 moves is enough for a twist
+    print("AI response (1 dodge in last 4):", ai_brain.throw_twist())
+
+    # Demonstrate beast cost (more expensive)
+    print("\nAttempting to buy a knight_mount (base cost 10)...")
+    # Cost should be 10 * 1.5 = 15
+    print(bestiary.buy_beast('knight_mount'))
+    print(f"Coins remaining: {bestiary.coins}")
+
+
+if __name__ == "__main__":
+    run_game_scenario()


### PR DESCRIPTION
This commit introduces a difficulty setting to the game, with three levels: easy, medium, and hard.

The difficulty setting affects:
- The AI's behavior, making it more or less likely to trigger "twist" events.
- The cost of beasts in the bestiary, making them cheaper on easy and more expensive on hard.

The changes include:
- A `difficulty` attribute and `set_difficulty` method in `ModesManager`.
- `AIChaosBrain` and `BeastBestiary` are now aware of the difficulty setting and adjust their logic accordingly.
- A new `game.py` file has been added to demonstrate the new feature and serve as an example of how to use the classes.